### PR TITLE
Fix question capture send flow

### DIFF
--- a/SmolLens/Services/CameraService.swift
+++ b/SmolLens/Services/CameraService.swift
@@ -14,7 +14,7 @@ class CameraService: NSObject, ObservableObject {
 
     private let output = AVCapturePhotoOutput()
 
-    var photoCaptureCompletion: (() -> Void)?
+    var photoCaptureCompletion: ((UIImage?) -> Void)?
 
     override init() {
         self.session = AVCaptureSession()
@@ -87,7 +87,7 @@ class CameraService: NSObject, ObservableObject {
         }
     }
 
-    func capturePhoto(completion: @escaping () -> Void) {
+    func capturePhoto(completion: @escaping (UIImage?) -> Void) {
         logger.info("Initiating photo capture")
         self.photoCaptureCompletion = completion
 
@@ -119,16 +119,20 @@ extension CameraService: AVCapturePhotoCaptureDelegate {
         }
 
         if let imageData = photo.fileDataRepresentation() {
-            self.capturedImage = UIImage(data: imageData)
-            self.isCaptured = true
-            self.session.stopRunning()
-            logger.info("Photo captured successfully")
+            let image = UIImage(data: imageData)
 
             DispatchQueue.main.async {
-                self.photoCaptureCompletion?()
+                self.capturedImage = image
+                self.isCaptured = true
+                self.session.stopRunning()
+                self.logger.info("Photo captured successfully")
+                self.photoCaptureCompletion?(image)
             }
         } else {
             logger.error("Failed to process captured photo data")
+            DispatchQueue.main.async {
+                self.photoCaptureCompletion?(nil)
+            }
         }
     }
 }

--- a/SmolLens/Views/CameraContainerView.swift
+++ b/SmolLens/Views/CameraContainerView.swift
@@ -103,15 +103,15 @@ struct AskView: View {
                     .foregroundStyle(.primary)
 
                 Button(action: {
-                    Task {
-                        camera.capturePhoto {
-                            if let image = camera.capturedImage {
-                                analysisService.analyzeImage(image, prompt: questionText)
-                                isAskViewPresented = false
-                                camera.reset()
-                                questionText = ""
-                            }
+                    let prompt = questionText
+                    camera.capturePhoto { image in
+                        guard let image else {
+                            return
                         }
+                        analysisService.analyzeImage(image, prompt: prompt)
+                        isAskViewPresented = false
+                        camera.reset()
+                        questionText = ""
                     }
                 }) {
                     Image(systemName: "paperplane.fill")
@@ -206,7 +206,7 @@ struct BottomControlsView: View {
                     } else {
                         logger.info("Initiating photo capture sequence")
                         camera.capturePhoto {
-                            if let image = camera.capturedImage {
+                            if let image = $0 {
                                 analysisService.analyzeImage(image)
                             }
                             camera.reset()


### PR DESCRIPTION
## Summary
- pass the captured photo directly through the capture completion
- snapshot the question prompt before capture so reset timing cannot clear it first
- update the normal capture path to use the completion image too

## Verification
- xcrun swiftc -parse -target arm64-apple-ios18.0-simulator -sdk $(xcrun --sdk iphonesimulator --show-sdk-path) SmolLens/Services/CameraService.swift SmolLens/Views/CameraContainerView.swift
- git diff --check

Closes #2